### PR TITLE
Run setuid as jetty with JETTY_BASE=/var/lib/jetty

### DIFF
--- a/9-jre7/Dockerfile
+++ b/9-jre7/Dockerfile
@@ -24,5 +24,14 @@ RUN curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz \
     && rm -fr demo-base javadoc \
     && rm jetty.tar.gz*
 
+ENV JETTY_BASE /var/lib/jetty
+RUN mkdir -p "$JETTY_BASE" \
+    && chown jetty:jetty "$JETTY_BASE"
+WORKDIR $JETTY_BASE
+
+# Get the list of modules in the default start.ini and build new base with those modules, then add setuid
+RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd="$(grep -- ^--module= "$JETTY_HOME/start.ini" | cut -d= -f2 | paste -d, -s)" \
+    && java -jar "$JETTY_HOME/start.jar" --add-to-startd=setuid
+
 EXPOSE 8080
 CMD ["jetty.sh", "run"]

--- a/9-jre8/Dockerfile
+++ b/9-jre8/Dockerfile
@@ -24,5 +24,14 @@ RUN curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz \
     && rm -fr demo-base javadoc \
     && rm jetty.tar.gz*
 
+ENV JETTY_BASE /var/lib/jetty
+RUN mkdir -p "$JETTY_BASE" \
+    && chown jetty:jetty "$JETTY_BASE"
+WORKDIR $JETTY_BASE
+
+# Get the list of modules in the default start.ini and build new base with those modules, then add setuid
+RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd="$(grep -- ^--module= "$JETTY_HOME/start.ini" | cut -d= -f2 | paste -d, -s)" \
+    && java -jar "$JETTY_HOME/start.jar" --add-to-startd=setuid
+
 EXPOSE 8080
 CMD ["jetty.sh", "run"]


### PR DESCRIPTION
This patch updates the `jetty` image to take advantage of the `JETTY_BASE` feature in Jetty 9.1+. Jetty now runs from `/var/lib/jetty`, which is owned by user `jetty`.

The `/var/lib/jetty` directory is created using Jetty's `start.jar --add-to-startd` functionality based on the list of modules in `$JETTY_HOME/start.ini`. The Dockerfile then adds Jetty's `setuid` to direct Jetty to drop privileges after startup.

Fixes #1 
