### PR TITLE
Support running Jetty in read-only containers

### DIFF
--- a/9-jre7/Dockerfile
+++ b/9-jre7/Dockerfile
@@ -25,8 +25,7 @@ RUN curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz \
     && rm jetty.tar.gz*
 
 ENV JETTY_BASE /var/lib/jetty
-RUN mkdir -p "$JETTY_BASE" \
-    && chown jetty:jetty "$JETTY_BASE"
+RUN mkdir -p "$JETTY_BASE" && chown jetty:jetty "$JETTY_BASE"
 WORKDIR $JETTY_BASE
 
 # Get the list of modules in the default start.ini and build new base with those modules, then add setuid

--- a/9-jre7/Dockerfile
+++ b/9-jre7/Dockerfile
@@ -36,7 +36,6 @@ ENV JETTY_RUN /run/jetty
 ENV JETTY_STATE $JETTY_RUN/jetty.state
 ENV TMPDIR /tmp/jetty
 RUN mkdir -p "$JETTY_RUN" "$TMPDIR" && chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR"
-VOLUME $JETTY_RUN $TMPDIR
 
 EXPOSE 8080
 CMD ["jetty.sh", "run"]

--- a/9-jre7/Dockerfile
+++ b/9-jre7/Dockerfile
@@ -34,9 +34,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd="$(grep -- ^--module= "$JE
 
 ENV JETTY_RUN /run/jetty
 ENV JETTY_STATE $JETTY_RUN/jetty.state
-ENV TMPDIR $JETTY_RUN/tmp
-RUN mkdir -p "$JETTY_RUN/tmp" && chown -R jetty:jetty "$JETTY_RUN"
-VOLUME $JETTY_RUN
+ENV TMPDIR /tmp/jetty
+RUN mkdir -p "$JETTY_RUN" "$TMPDIR" && chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR"
+VOLUME $JETTY_RUN $TMPDIR
 
 EXPOSE 8080
 CMD ["jetty.sh", "run"]

--- a/9-jre7/Dockerfile
+++ b/9-jre7/Dockerfile
@@ -32,5 +32,11 @@ WORKDIR $JETTY_BASE
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd="$(grep -- ^--module= "$JETTY_HOME/start.ini" | cut -d= -f2 | paste -d, -s)" \
     && java -jar "$JETTY_HOME/start.jar" --add-to-startd=setuid
 
+ENV JETTY_RUN /run/jetty
+ENV JETTY_STATE $JETTY_RUN/jetty.state
+ENV TMPDIR $JETTY_RUN/tmp
+RUN mkdir -p "$JETTY_RUN/tmp" && chown -R jetty:jetty "$JETTY_RUN"
+VOLUME $JETTY_RUN
+
 EXPOSE 8080
 CMD ["jetty.sh", "run"]

--- a/9-jre8/Dockerfile
+++ b/9-jre8/Dockerfile
@@ -25,8 +25,7 @@ RUN curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz \
     && rm jetty.tar.gz*
 
 ENV JETTY_BASE /var/lib/jetty
-RUN mkdir -p "$JETTY_BASE" \
-    && chown jetty:jetty "$JETTY_BASE"
+RUN mkdir -p "$JETTY_BASE" && chown jetty:jetty "$JETTY_BASE"
 WORKDIR $JETTY_BASE
 
 # Get the list of modules in the default start.ini and build new base with those modules, then add setuid

--- a/9-jre8/Dockerfile
+++ b/9-jre8/Dockerfile
@@ -36,7 +36,6 @@ ENV JETTY_RUN /run/jetty
 ENV JETTY_STATE $JETTY_RUN/jetty.state
 ENV TMPDIR /tmp/jetty
 RUN mkdir -p "$JETTY_RUN" "$TMPDIR" && chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR"
-VOLUME $JETTY_RUN $TMPDIR
 
 EXPOSE 8080
 CMD ["jetty.sh", "run"]

--- a/9-jre8/Dockerfile
+++ b/9-jre8/Dockerfile
@@ -34,9 +34,9 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd="$(grep -- ^--module= "$JE
 
 ENV JETTY_RUN /run/jetty
 ENV JETTY_STATE $JETTY_RUN/jetty.state
-ENV TMPDIR $JETTY_RUN/tmp
-RUN mkdir -p "$JETTY_RUN/tmp" && chown -R jetty:jetty "$JETTY_RUN"
-VOLUME $JETTY_RUN
+ENV TMPDIR /tmp/jetty
+RUN mkdir -p "$JETTY_RUN" "$TMPDIR" && chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR"
+VOLUME $JETTY_RUN $TMPDIR
 
 EXPOSE 8080
 CMD ["jetty.sh", "run"]

--- a/9-jre8/Dockerfile
+++ b/9-jre8/Dockerfile
@@ -32,5 +32,11 @@ WORKDIR $JETTY_BASE
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd="$(grep -- ^--module= "$JETTY_HOME/start.ini" | cut -d= -f2 | paste -d, -s)" \
     && java -jar "$JETTY_HOME/start.jar" --add-to-startd=setuid
 
+ENV JETTY_RUN /run/jetty
+ENV JETTY_STATE $JETTY_RUN/jetty.state
+ENV TMPDIR $JETTY_RUN/tmp
+RUN mkdir -p "$JETTY_RUN/tmp" && chown -R jetty:jetty "$JETTY_RUN"
+VOLUME $JETTY_RUN
+
 EXPOSE 8080
 CMD ["jetty.sh", "run"]


### PR DESCRIPTION
This PR updates the `jetty` image to be able to easily run as a read-only container

```
docker run -d --read-only -v /tmp/jetty -v /run/jetty jetty
```

It makes the following changes:
1. Creates `/run/jetty` and `/tmp/jetty` directories owned by `jetty:jetty`
2. Sets `JETTY_STATE=/run/jetty/jetty.state` and `TMPDIR=/tmp/jetty`
3. <s>Declares `/run/jetty` and `/tmp/jetty` to be `VOLUME`s</s>

<s>The `VOLUME` declarations could be dropped and replaced with instructions to run with `--read-only -v /run/jetty -v /tmp/jetty`, but I'm in favor of these service-specific `/run` and `/tmp` directories being `VOLUME`s in general.</s>

Of course, the above command will run a pretty useless `jetty` container unless you also mount in `/var/lib/jetty/webapps` or otherwise configure the server to do something useful.
