### PR TITLE
Directly execute start.jar rather than use shell script

### DIFF
--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -27,7 +27,6 @@ RUN set -xe \
 	&& curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc \
 	&& gpg --verify jetty.tar.gz.asc \
 	&& tar -xvf jetty.tar.gz --strip-components=1 \
-	&& sed -i '/jetty-logging/d' etc/jetty.conf \
 	&& rm -fr demo-base javadoc \
 	&& rm jetty.tar.gz*
 

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -3,8 +3,12 @@ FROM java:8-jre
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r jetty && useradd -r -g jetty jetty
 
+ENV JETTY_VERSION 9.3.2.v20150730
 ENV JETTY_HOME /usr/local/jetty
-RUN mkdir -p "$JETTY_HOME"
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+RUN mkdir -p "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR"
+
 WORKDIR $JETTY_HOME
 
 # see http://dev.eclipse.org/mhonarc/lists/jetty-users/msg05220.html
@@ -19,9 +23,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV JETTY_VERSION 9.3.2.v20150730
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
-
 RUN set -xe \
 	&& curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz \
 	&& curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc \
@@ -30,19 +32,15 @@ RUN set -xe \
 	&& rm -fr demo-base javadoc \
 	&& rm jetty.tar.gz*
 
-ENV JETTY_BASE /var/lib/jetty
-RUN mkdir -p "$JETTY_BASE" && chown jetty:jetty "$JETTY_BASE"
-WORKDIR $JETTY_BASE
+ADD docker-entrypoint.bash "$JETTY_BASE/docker-entrypoint.bash"
 
-# Get the list of modules in the default start.ini and build new base with those modules, then add setuid
+WORKDIR $JETTY_BASE
+# Get the list of modules in the default start.ini and build new base with those modules, then add setuid, chown etc.
 RUN modules="$(grep -- ^--module= "$JETTY_HOME/start.ini" | cut -d= -f2 | paste -d, -s)" \
 	&& set -xe \
-	&& java -jar "$JETTY_HOME/start.jar" --add-to-startd="$modules,setuid"
-
-ENV TMPDIR /tmp/jetty
-RUN set -xe \
-	&& mkdir -p "$TMPDIR" \
-	&& chown -R jetty:jetty "$TMPDIR"
+	&& java -jar "$JETTY_HOME/start.jar" --add-to-startd="$modules,setuid" \
+	&& chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" \
+	&& chmod +x "$JETTY_BASE/docker-entrypoint.bash"
 
 EXPOSE 8080
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]
+ENTRYPOINT ["/var/lib/jetty/docker-entrypoint.bash"];

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -4,7 +4,6 @@ FROM java:8-jre
 RUN groupadd -r jetty && useradd -r -g jetty jetty
 
 ENV JETTY_HOME /usr/local/jetty
-ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
@@ -49,4 +48,5 @@ RUN set -xe \
 	&& chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR"
 
 EXPOSE 8080
-CMD ["jetty.sh", "run"]
+CMD []
+ENTRYPOINT ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -40,13 +40,10 @@ RUN modules="$(grep -- ^--module= "$JETTY_HOME/start.ini" | cut -d= -f2 | paste 
 	&& set -xe \
 	&& java -jar "$JETTY_HOME/start.jar" --add-to-startd="$modules,setuid"
 
-ENV JETTY_RUN /run/jetty
-ENV JETTY_STATE $JETTY_RUN/jetty.state
 ENV TMPDIR /tmp/jetty
 RUN set -xe \
-	&& mkdir -p "$JETTY_RUN" "$TMPDIR" \
-	&& chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR"
+	&& mkdir -p "$TMPDIR" \
+	&& chown -R jetty:jetty "$TMPDIR"
 
 EXPOSE 8080
-CMD []
-ENTRYPOINT ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]

--- a/9.3-jre8/docker-entrypoint.bash
+++ b/9.3-jre8/docker-entrypoint.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+if [ "$1" = /usr/local/jetty/bin/jetty.sh ]; then
+	cat >&2 <<- 'EOWARN'
+********************************************************************
+WARNING: Use of jetty.sh from this image is deprecated and may
+be removed at some point in the future.
+
+See the documentation for guidance on extending this image:
+https://github.com/docker-library/docs/tree/master/jetty
+********************************************************************
+EOWARN
+fi
+
+if ! type "$1" &>/dev/null; then
+	set -- java -jar "-Djava.io.tmpdir=$TMPDIR" "$JETTY_HOME/start.jar" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Rather than use the shell script to start Jetty, I believe it would be better to directly run the start.jar

The jetty shell script is really intended as an /etc/init.d script and does all the location of java, home and base, which is already known in the ENV settings of the Dockerfile.

So we can avoid creating a shell process, which will be some time and space savings, but more importantly we are able to pass in command line arguments to the start.jar, so you can do things like:

```
docker run jetty-9.3-jre8 --list-config
```

To see the configuration of the image.

```
docker run jetty-9.3-jre8 --module=debug
```

runs jetty, but with the debug module enabled

```
docker run jetty-9.3-jre8 --dry-run
```

Reports the exact command line that would be run by start.jar, which can be used to craft an Entry-Point for another image that avoids even the start.jar startup time and memory.

I've only updated 9.3 image at the moment.... if this is considered a good idea I can do all the versions... or perhaps we only do it for versions going forward?  or perhaps it is a bad idea for some reason I don't know yet???
