### PR TITLE
Update to Jetty 9.3.7

### DIFF
--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -20,7 +20,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV JETTY_VERSION 9.3.6.v20151106
+ENV JETTY_VERSION 9.3.7.v20160115
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
 
 RUN set -xe \


### PR DESCRIPTION
Includes a fix for the SLOTH vulnerability (cf. https://github.com/eclipse/jetty.project/commit/0a1b0b2bc69ea7e7f5f44992f47a84f926cdeebb)

Fixes #24 
