### PR TITLE
Update "make library" to generate new format

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,88 +1,102 @@
 #!/bin/bash
 set -ueo pipefail
+shopt -s globstar
 
 declare -A aliases
 aliases=(
 	[9.2-jre7]='jre7'
 	[9.3-jre8]='latest jre8'
 )
-defaultJava='8'
-defaultSuffix="jre${defaultJava}"
+defaultJdk="jre8"
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
-paths=( */Dockerfile )
-paths=( $( printf '%s\n' "${paths[@]%/Dockerfile}" | sort -Vr ) )
-url='git://github.com/appropriate/docker-jetty'
+paths=( **/*/Dockerfile )
+paths=( $( printf '%s\n' "${paths[@]%/Dockerfile}" | sort -t/ -k 1,1Vr -k 2,2 ) )
+url='https://github.com/appropriate/docker-jetty.git'
 
-echo '# maintainer: Mike Dillon <mike@appropriate.io> (@md5)'
-echo '# maintainer: Greg Wilkins <gregw@webtide.com> (@gregw)'
+cat <<-EOH
+	Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
+	             Greg Wilkins <gregw@webtide.com> (@gregw)
+	GitRepo: $url
+EOH
 
-declare -A tagsSeen
-tagsSeen=()
-outputTag() {
+declare -a tags
+declare -A tagsSeen=()
+addTag() {
 	local tag="$1"
-	local url="$2"
-	local commit="$3"
-	local path="$4"
 
 	if [ ${#tagsSeen[$tag]} -gt 0 ]; then
 		return
 	fi
 
-	echo "$tag: ${url}@${commit} $path"
+	tags+=("$tag")
 	tagsSeen[$tag]=1
 }
 
 for path in "${paths[@]}"; do
-	for variant in '' alpine; do
-		[ -f "$path${variant:+/$variant}/Dockerfile" ] || continue
+	tags=()
 
-		echo
+	directory="$path"
+	commit="$(git log -1 --format='format:%H' -- "$directory")"
+	version="$(grep -m1 'ENV JETTY_VERSION ' "$directory/Dockerfile" | cut -d' ' -f3)"
 
-		commit="$(git log -1 --format='format:%H' -- "$path${variant:+/$variant}")"
+	# Determine if this is a variant image
+	if [[ "$path" = */* ]]; then
+		variant=${path#*/} # "alpine"
+		path=${path%/*}
+	else
+		variant=''
+	fi
 
-		suffix="${path#*-}" # "jre7"
+	# Determine the JDK
+	jdk=${path#*-} # "jre7"
 
-		version="$(grep -m1 'ENV JETTY_VERSION ' "$path${variant:+/$variant}/Dockerfile" | cut -d' ' -f3)"
-
-		if [[ "$version" == *.v* ]]; then
-			# Release version
-			versionAliases=()
-			while [[ "$version" == *.* ]]; do
-				version="${version%.*}"
-				versionAliases+=("$version")
-			done
-		else
-			# Non-release version
-			versionAliases=("$version")
-		fi
-
-		# Output ${versionAliases[@]} without suffixes
-		# e.g. 9.2.10, 9.2, 9, 9.3-alpine
-		if [ "$suffix" = "$defaultSuffix" ]; then
-			for va in "${versionAliases[@]}"; do
-				outputTag "$va${variant:+-$variant}" "$url" "$commit" "$path${variant:+/$variant}"
-			done
-		fi
-
-		# Output ${versionAliases[@]} with suffixes
-		# e.g. 9.2.10-jre7, 9.2-jre7, 9-jre7, 9-jre8-alpine
-		for va in "${versionAliases[@]}"; do
-			outputTag "$va-$suffix${variant:+-$variant}" "$url" "$commit" "$path${variant:+/$variant}"
+	# Collect the potential version aliases
+	declare -a versionAliases
+	if [[ "$version" == *.v* ]]; then
+		# Release version
+		versionAliases=()
+		while [[ "$version" == *.* ]]; do
+			version="${version%.*}"
+			versionAliases+=("$version")
 		done
+	else
+		# Non-release version
+		versionAliases=("$version")
+	fi
 
-		# Output custom aliases
-		# e.g. latest, jre7, jre8, latest-alpine
-		if [ ${#aliases[$path]} -gt 0 ]; then
-			for va in ${aliases[$path]}; do
-				if [ ! -z "$variant" -a "$va" = 'latest' ]; then
-					va="$variant"
-				else
-					va="$va${variant:+-$variant}"
-				fi
-				outputTag "$va" "$url" "$commit" "$path${variant:+/$variant}"
-			done
-		fi
+	# Output ${versionAliases[@]} without jdk
+	# e.g. 9.2.10, 9.2, 9, 9.3-alpine
+	if [ "$jdk" = "$defaultJdk" ]; then
+		for va in "${versionAliases[@]}"; do
+			addTag "$va${variant:+-$variant}"
+		done
+	fi
+
+	# Output ${versionAliases[@]} with suffixes
+	# e.g. 9.2.10-jre7, 9.2-jre7, 9-jre7, 9-jre8-alpine
+	for va in "${versionAliases[@]}"; do
+		addTag "$va-$jdk${variant:+-$variant}"
 	done
+
+	# Output custom aliases
+	# e.g. latest, jre7, jre8, latest-alpine
+	if [ ${#aliases[$path]} -gt 0 ]; then
+		for va in ${aliases[$path]}; do
+			if [ ! -z "$variant" -a "$va" = 'latest' ]; then
+				va="$variant"
+			else
+				va="$va${variant:+-$variant}"
+			fi
+			addTag "$va"
+		done
+	fi
+
+	cat <<-EOE
+
+		Tags:$(IFS=, ; echo "${tags[*]/#/ }")
+		Directory: $directory
+		GitCommit: $commit
+	EOE
 done

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -66,7 +66,7 @@ for path in "${paths[@]}"; do
 		versionAliases=("$version")
 	fi
 
-	# Output ${versionAliases[@]} without jdk
+	# Output ${versionAliases[@]} without JDK
 	# e.g. 9.2.10, 9.2, 9, 9.3-alpine
 	if [ "$jdk" = "$defaultJdk" ]; then
 		for va in "${versionAliases[@]}"; do
@@ -74,14 +74,14 @@ for path in "${paths[@]}"; do
 		done
 	fi
 
-	# Output ${versionAliases[@]} with suffixes
+	# Output ${versionAliases[@]} with JDK suffixes
 	# e.g. 9.2.10-jre7, 9.2-jre7, 9-jre7, 9-jre8-alpine
 	for va in "${versionAliases[@]}"; do
 		addTag "$va-$jdk${variant:+-$variant}"
 	done
 
 	# Output custom aliases
-	# e.g. latest, jre7, jre8, latest-alpine
+	# e.g. latest, jre7, jre8, alpine
 	if [ ${#aliases[$path]} -gt 0 ]; then
 		for va in ${aliases[$path]}; do
 			if [ ! -z "$variant" -a "$va" = 'latest' ]; then


### PR DESCRIPTION
The Docker Official Images process is now using a new format for the library file (cf. https://github.com/docker-library/official-images/pull/1793). I've already used the version of `generate-stackbrew-library.sh` from this branch to update the `jetty` image (cf. https://github.com/docker-library/official-images/pull/1808), so I know it works fine.
