### PR TITLE
Fix the arg order for the entrypoint implied CMD

### DIFF
--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -23,7 +23,7 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java -jar "-Djava.io.tmpdir=$TMPDIR" "$JETTY_HOME/start.jar" "$@"
+	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
 exec "$@"

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -23,7 +23,7 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java -jar "-Djava.io.tmpdir=$TMPDIR" "$JETTY_HOME/start.jar" "$@"
+	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
 exec "$@"

--- a/9.3-jre8/alpine/docker-entrypoint.sh
+++ b/9.3-jre8/alpine/docker-entrypoint.sh
@@ -23,7 +23,7 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java -jar "-Djava.io.tmpdir=$TMPDIR" "$JETTY_HOME/start.jar" "$@"
+	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
 exec "$@"

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -23,7 +23,7 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java -jar "-Djava.io.tmpdir=$TMPDIR" "$JETTY_HOME/start.jar" "$@"
+	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,7 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java -jar "-Djava.io.tmpdir=$TMPDIR" "$JETTY_HOME/start.jar" "$@"
+	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Even though the JDK accepts "-jar -Dfoo name.jar", it doesn't seem like it should actually work
