### PR TITLE
Fix #37 Allow JVM options to be set via JAVA_OPTIONS

### DIFF
--- a/9.2-jre7/Dockerfile
+++ b/9.2-jre7/Dockerfile
@@ -51,4 +51,4 @@ COPY docker-entrypoint.sh /
 
 EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -23,7 +23,19 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+if [ -n "$TMPDIR" ] ; then
+	case "$JAVA_OPTIONS" in
+		*-Djava.io.tmpdir=*) ;;
+		*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+	esac
+fi
+
+if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
+        shift
+	set -- java $JAVA_OPTIONS "$@"
 fi
 
 exec "$@"

--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -34,7 +34,7 @@ if [ -n "$TMPDIR" ] ; then
 fi
 
 if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
-        shift
+	shift
 	set -- java $JAVA_OPTIONS "$@"
 fi
 

--- a/9.2-jre8/Dockerfile
+++ b/9.2-jre8/Dockerfile
@@ -51,4 +51,4 @@ COPY docker-entrypoint.sh /
 
 EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -23,7 +23,19 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+if [ -n "$TMPDIR" ] ; then
+	case "$JAVA_OPTIONS" in
+		*-Djava.io.tmpdir=*) ;;
+		*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+	esac
+fi
+
+if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
+        shift
+	set -- java $JAVA_OPTIONS "$@"
 fi
 
 exec "$@"

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -34,7 +34,7 @@ if [ -n "$TMPDIR" ] ; then
 fi
 
 if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
-        shift
+	shift
 	set -- java $JAVA_OPTIONS "$@"
 fi
 

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -50,4 +50,4 @@ COPY docker-entrypoint.sh /
 
 EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -33,8 +33,8 @@ if [ -n "$TMPDIR" ] ; then
 	esac
 fi
 
-if [ "$1" = "java" ] ; then
-        shift
+if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
+	shift
 	set -- java $JAVA_OPTIONS "$@"
 fi
 

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -23,7 +23,19 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+if [ -n "$TMPDIR" ] ; then
+	case "$JAVA_OPTIONS" in
+		*-Djava.io.tmpdir=*) ;;
+		*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+	esac
+fi
+
+if [ "$1" = "java" ] ; then
+        shift
+	set -- java $JAVA_OPTIONS "$@"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,19 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+if [ -n "$TMPDIR" ] ; then
+	case "$JAVA_OPTIONS" in
+		*-Djava.io.tmpdir=*) ;;
+		*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+	esac
+fi
+
+if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
+        shift
+	set -- java $JAVA_OPTIONS "$@"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,7 +34,7 @@ if [ -n "$TMPDIR" ] ; then
 fi
 
 if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
-        shift
+	shift
 	set -- java $JAVA_OPTIONS "$@"
 fi
 


### PR DESCRIPTION
Fixes #37 by allowing JAVA_OPTIONS to be set.
Since this takes the approach of the entry point script modifying all java commands, this also moves the setting of TMPDIR to a conditional adjustment of JAVA_OPTIONS.  
