### PR TITLE
Fix #37 Allow JVM options to be set via JAVA_OPTIONS

### DIFF
--- a/9.2-jre7/Dockerfile
+++ b/9.2-jre7/Dockerfile
@@ -40,12 +40,10 @@ RUN modules="$(grep -- ^--module= "$JETTY_HOME/start.ini" | cut -d= -f2 | paste 
 	&& set -xe \
 	&& java -jar "$JETTY_HOME/start.jar" --add-to-startd="$modules,setuid"
 
-ENV JETTY_RUN /run/jetty
-ENV JETTY_STATE $JETTY_RUN/jetty.state
 ENV TMPDIR /tmp/jetty
 RUN set -xe \
-	&& mkdir -p "$JETTY_RUN" "$TMPDIR" \
-	&& chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR" "$JETTY_BASE"
+	&& mkdir -p "$TMPDIR" \
+	&& chown -R jetty:jetty "$TMPDIR" "$JETTY_BASE"
 
 COPY docker-entrypoint.sh /
 

--- a/9.2-jre8/Dockerfile
+++ b/9.2-jre8/Dockerfile
@@ -40,12 +40,10 @@ RUN modules="$(grep -- ^--module= "$JETTY_HOME/start.ini" | cut -d= -f2 | paste 
 	&& set -xe \
 	&& java -jar "$JETTY_HOME/start.jar" --add-to-startd="$modules,setuid"
 
-ENV JETTY_RUN /run/jetty
-ENV JETTY_STATE $JETTY_RUN/jetty.state
 ENV TMPDIR /tmp/jetty
 RUN set -xe \
-	&& mkdir -p "$JETTY_RUN" "$TMPDIR" \
-	&& chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR" "$JETTY_BASE"
+	&& mkdir -p "$TMPDIR" \
+	&& chown -R jetty:jetty "$TMPDIR" "$JETTY_BASE"
 
 COPY docker-entrypoint.sh /
 

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -39,12 +39,10 @@ RUN modules="$(grep -- ^--module= "$JETTY_HOME/start.ini" | cut -d= -f2 | paste 
 	&& set -xe \
 	&& java -jar "$JETTY_HOME/start.jar" --add-to-startd="$modules,setuid"
 
-ENV JETTY_RUN /run/jetty
-ENV JETTY_STATE $JETTY_RUN/jetty.state
 ENV TMPDIR /tmp/jetty
 RUN set -xe \
-	&& mkdir -p "$JETTY_RUN" "$TMPDIR" \
-	&& chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR" "$JETTY_BASE"
+	&& mkdir -p "$TMPDIR" \
+	&& chown -R jetty:jetty "$TMPDIR" "$JETTY_BASE"
 
 COPY docker-entrypoint.sh /
 

--- a/9.3-jre8/alpine/Dockerfile
+++ b/9.3-jre8/alpine/Dockerfile
@@ -51,15 +51,13 @@ RUN set -xe \
 
 WORKDIR $JETTY_BASE
 
-ENV JETTY_RUN /run/jetty
-ENV JETTY_STATE $JETTY_RUN/jetty.state
 ENV TMPDIR /tmp/jetty
 RUN set -xe \
-	&& mkdir -p "$JETTY_RUN" "$TMPDIR" \
-	&& chown -R jetty:jetty "$JETTY_RUN" "$TMPDIR" "$JETTY_BASE"
+	&& mkdir -p "$TMPDIR" \
+	&& chown -R jetty:jetty "$TMPDIR" "$JETTY_BASE"
 
 COPY docker-entrypoint.sh /
 
 EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["java","-Djava.io.tmpdir=/tmp/jetty","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/9.3-jre8/alpine/docker-entrypoint.sh
+++ b/9.3-jre8/alpine/docker-entrypoint.sh
@@ -23,7 +23,19 @@ if [ "$1" = jetty.sh ]; then
 fi
 
 if ! command -v -- "$1" >/dev/null 2>&1 ; then
-	set -- java "-Djava.io.tmpdir=$TMPDIR" -jar "$JETTY_HOME/start.jar" "$@"
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+if [ -n "$TMPDIR" ] ; then
+	case "$JAVA_OPTIONS" in
+		*-Djava.io.tmpdir=*) ;;
+		*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+	esac
+fi
+
+if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
+	shift
+	set -- java $JAVA_OPTIONS "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Updated the alpine image with same changes previously made for #37
removed the unused ENV variables JETTY_RUN and JETTY_STATE
