### PR TITLE
Issue #63 Bypass start.jar

### DIFF
--- a/9.2-jre7/Dockerfile
+++ b/9.2-jre7/Dockerfile
@@ -56,7 +56,7 @@ RUN set -xe \
 	&& mkdir -p "$TMPDIR" \
 	&& chown -R jetty:jetty "$TMPDIR"
 
-COPY docker-entrypoint.sh /
+COPY docker-entrypoint.sh generate-jetty-start.sh /
 
 EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -65,11 +65,22 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 		esac
 	done
 
-	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
-		set -- $(cat /jetty-quickstart)
+	if [ -f /jetty-start ] ; then
+		if [ $JETTY_BASE/start.d -nt /jetty-start ] ; then
+			cat >&2 <<- 'EOWARN'
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the /jetty-start files was generated. Please either delete 
+			         the /jetty-start file or re-run /generate-jetty-start.sh 
+			         from a Dockerfile
+			********************************************************************
+			EOWARN
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from /jetty-start
+		set -- $(cat /jetty-start)
 	else
 		# Do a jetty dry run to set the final command
-		set -- $("$@" --dry-run)
+		set -- $("$@" --dry-run | sed 's/\\$//' )
 	fi
 fi
 

--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -38,4 +38,39 @@ if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
 	set -- java $JAVA_OPTIONS "$@"
 fi
 
+if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-to-start* |\
+			--create-files |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			-v )\
+			# It is a terminating command, so exec directly
+		        exec "$@"
+		esac
+	done
+
+	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
+		set -- $(cat /jetty-quickstart)
+	else
+		# Do a jetty dry run to set the final command
+		set -- $("$@" --dry-run)
+	fi
+fi
+
 exec "$@"

--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -61,7 +61,7 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 			--version |\
 			-v )\
 			# It is a terminating command, so exec directly
-		        exec "$@"
+			exec "$@"
 		esac
 	done
 

--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -81,13 +81,12 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	else
 		# Do a jetty dry run to set the final command
 		"$@" --dry-run > /jetty-start
-		EXIT=$?
 		if [ $(egrep -v '\\$' /jetty-start | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
 			cat /jetty-start \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
-			exit $EXIT
+			exit
 		fi
 		set -- $(sed 's/\\$//' /jetty-start)
 	fi

--- a/9.2-jre7/generate-jetty-start.sh
+++ b/9.2-jre7/generate-jetty-start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -f /jetty-start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start

--- a/9.2-jre8/Dockerfile
+++ b/9.2-jre8/Dockerfile
@@ -56,7 +56,7 @@ RUN set -xe \
 	&& mkdir -p "$TMPDIR" \
 	&& chown -R jetty:jetty "$TMPDIR"
 
-COPY docker-entrypoint.sh /
+COPY docker-entrypoint.sh generate-jetty-start.sh /
 
 EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -65,11 +65,22 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 		esac
 	done
 
-	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
-		set -- $(cat /jetty-quickstart)
+	if [ -f /jetty-start ] ; then
+		if [ $JETTY_BASE/start.d -nt /jetty-start ] ; then
+			cat >&2 <<- 'EOWARN'
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the /jetty-start files was generated. Please either delete 
+			         the /jetty-start file or re-run /generate-jetty-start.sh 
+			         from a Dockerfile
+			********************************************************************
+			EOWARN
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from /jetty-start
+		set -- $(cat /jetty-start)
 	else
 		# Do a jetty dry run to set the final command
-		set -- $("$@" --dry-run)
+		set -- $("$@" --dry-run | sed 's/\\$//' )
 	fi
 fi
 

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -38,4 +38,39 @@ if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
 	set -- java $JAVA_OPTIONS "$@"
 fi
 
+if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-to-start* |\
+			--create-files |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			-v )\
+			# It is a terminating command, so exec directly
+		        exec "$@"
+		esac
+	done
+
+	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
+		set -- $(cat /jetty-quickstart)
+	else
+		# Do a jetty dry run to set the final command
+		set -- $("$@" --dry-run)
+	fi
+fi
+
 exec "$@"

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -61,7 +61,7 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 			--version |\
 			-v )\
 			# It is a terminating command, so exec directly
-		        exec "$@"
+			exec "$@"
 		esac
 	done
 

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -81,13 +81,12 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	else
 		# Do a jetty dry run to set the final command
 		"$@" --dry-run > /jetty-start
-		EXIT=$?
 		if [ $(egrep -v '\\$' /jetty-start | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
 			cat /jetty-start \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
-			exit $EXIT
+			exit
 		fi
 		set -- $(sed 's/\\$//' /jetty-start)
 	fi

--- a/9.2-jre8/generate-jetty-start.sh
+++ b/9.2-jre8/generate-jetty-start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -f /jetty-start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -56,7 +56,7 @@ RUN set -xe \
 	&& mkdir -p "$TMPDIR" \
 	&& chown -R jetty:jetty "$TMPDIR"
 
-COPY docker-entrypoint.sh /
+COPY docker-entrypoint.sh generate-jetty-start.sh /
 
 EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/9.3-jre8/alpine/docker-entrypoint.sh
+++ b/9.3-jre8/alpine/docker-entrypoint.sh
@@ -65,11 +65,22 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 		esac
 	done
 
-	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
-		set -- $(cat /jetty-quickstart)
+	if [ -f /jetty-start ] ; then
+		if [ $JETTY_BASE/start.d -nt /jetty-start ] ; then
+			cat >&2 <<- 'EOWARN'
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the /jetty-start files was generated. Please either delete 
+			         the /jetty-start file or re-run /generate-jetty-start.sh 
+			         from a Dockerfile
+			********************************************************************
+			EOWARN
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from /jetty-start
+		set -- $(cat /jetty-start)
 	else
 		# Do a jetty dry run to set the final command
-		set -- $("$@" --dry-run)
+		set -- $("$@" --dry-run | sed 's/\\$//' )
 	fi
 fi
 

--- a/9.3-jre8/alpine/docker-entrypoint.sh
+++ b/9.3-jre8/alpine/docker-entrypoint.sh
@@ -38,4 +38,39 @@ if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
 	set -- java $JAVA_OPTIONS "$@"
 fi
 
+if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-to-start* |\
+			--create-files |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			-v )\
+			# It is a terminating command, so exec directly
+		        exec "$@"
+		esac
+	done
+
+	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
+		set -- $(cat /jetty-quickstart)
+	else
+		# Do a jetty dry run to set the final command
+		set -- $("$@" --dry-run)
+	fi
+fi
+
 exec "$@"

--- a/9.3-jre8/alpine/docker-entrypoint.sh
+++ b/9.3-jre8/alpine/docker-entrypoint.sh
@@ -61,7 +61,7 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 			--version |\
 			-v )\
 			# It is a terminating command, so exec directly
-		        exec "$@"
+			exec "$@"
 		esac
 	done
 

--- a/9.3-jre8/alpine/docker-entrypoint.sh
+++ b/9.3-jre8/alpine/docker-entrypoint.sh
@@ -81,13 +81,12 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	else
 		# Do a jetty dry run to set the final command
 		"$@" --dry-run > /jetty-start
-		EXIT=$?
 		if [ $(egrep -v '\\$' /jetty-start | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
 			cat /jetty-start \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
-			exit $EXIT
+			exit
 		fi
 		set -- $(sed 's/\\$//' /jetty-start)
 	fi

--- a/9.3-jre8/alpine/generate-jetty-start.sh
+++ b/9.3-jre8/alpine/generate-jetty-start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -f /jetty-start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -65,11 +65,22 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 		esac
 	done
 
-	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
-		set -- $(cat /jetty-quickstart)
+	if [ -f /jetty-start ] ; then
+		if [ $JETTY_BASE/start.d -nt /jetty-start ] ; then
+			cat >&2 <<- 'EOWARN'
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the /jetty-start files was generated. Please either delete 
+			         the /jetty-start file or re-run /generate-jetty-start.sh 
+			         from a Dockerfile
+			********************************************************************
+			EOWARN
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from /jetty-start
+		set -- $(cat /jetty-start)
 	else
 		# Do a jetty dry run to set the final command
-		set -- $("$@" --dry-run)
+		set -- $("$@" --dry-run | sed 's/\\$//' )
 	fi
 fi
 

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -38,4 +38,39 @@ if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
 	set -- java $JAVA_OPTIONS "$@"
 fi
 
+if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-to-start* |\
+			--create-files |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			-v )\
+			# It is a terminating command, so exec directly
+		        exec "$@"
+		esac
+	done
+
+	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
+		set -- $(cat /jetty-quickstart)
+	else
+		# Do a jetty dry run to set the final command
+		set -- $("$@" --dry-run)
+	fi
+fi
+
 exec "$@"

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -61,7 +61,7 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 			--version |\
 			-v )\
 			# It is a terminating command, so exec directly
-		        exec "$@"
+			exec "$@"
 		esac
 	done
 

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -81,13 +81,12 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	else
 		# Do a jetty dry run to set the final command
 		"$@" --dry-run > /jetty-start
-		EXIT=$?
 		if [ $(egrep -v '\\$' /jetty-start | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
 			cat /jetty-start \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
-			exit $EXIT
+			exit
 		fi
 		set -- $(sed 's/\\$//' /jetty-start)
 	fi

--- a/9.3-jre8/generate-jetty-start.sh
+++ b/9.3-jre8/generate-jetty-start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -f /jetty-start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -53,7 +53,7 @@ RUN set -xe \
 	&& mkdir -p "$TMPDIR" \
 	&& chown -R jetty:jetty "$TMPDIR"
 
-COPY docker-entrypoint.sh /
+COPY docker-entrypoint.sh generate-jetty-start.sh /
 
 EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/9.4-jre8/alpine/docker-entrypoint.sh
+++ b/9.4-jre8/alpine/docker-entrypoint.sh
@@ -65,11 +65,22 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 		esac
 	done
 
-	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
-		set -- $(cat /jetty-quickstart)
+	if [ -f /jetty-start ] ; then
+		if [ $JETTY_BASE/start.d -nt /jetty-start ] ; then
+			cat >&2 <<- 'EOWARN'
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the /jetty-start files was generated. Please either delete 
+			         the /jetty-start file or re-run /generate-jetty-start.sh 
+			         from a Dockerfile
+			********************************************************************
+			EOWARN
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from /jetty-start
+		set -- $(cat /jetty-start)
 	else
 		# Do a jetty dry run to set the final command
-		set -- $("$@" --dry-run)
+		set -- $("$@" --dry-run | sed 's/\\$//' )
 	fi
 fi
 

--- a/9.4-jre8/alpine/docker-entrypoint.sh
+++ b/9.4-jre8/alpine/docker-entrypoint.sh
@@ -38,4 +38,39 @@ if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
 	set -- java $JAVA_OPTIONS "$@"
 fi
 
+if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-to-start* |\
+			--create-files |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			-v )\
+			# It is a terminating command, so exec directly
+		        exec "$@"
+		esac
+	done
+
+	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
+		set -- $(cat /jetty-quickstart)
+	else
+		# Do a jetty dry run to set the final command
+		set -- $("$@" --dry-run)
+	fi
+fi
+
 exec "$@"

--- a/9.4-jre8/alpine/docker-entrypoint.sh
+++ b/9.4-jre8/alpine/docker-entrypoint.sh
@@ -61,7 +61,7 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 			--version |\
 			-v )\
 			# It is a terminating command, so exec directly
-		        exec "$@"
+			exec "$@"
 		esac
 	done
 

--- a/9.4-jre8/alpine/docker-entrypoint.sh
+++ b/9.4-jre8/alpine/docker-entrypoint.sh
@@ -81,13 +81,12 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	else
 		# Do a jetty dry run to set the final command
 		"$@" --dry-run > /jetty-start
-		EXIT=$?
 		if [ $(egrep -v '\\$' /jetty-start | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
 			cat /jetty-start \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
-			exit $EXIT
+			exit
 		fi
 		set -- $(sed 's/\\$//' /jetty-start)
 	fi

--- a/9.4-jre8/alpine/generate-jetty-start.sh
+++ b/9.4-jre8/alpine/generate-jetty-start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -f /jetty-start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start

--- a/9.4-jre8/docker-entrypoint.sh
+++ b/9.4-jre8/docker-entrypoint.sh
@@ -65,11 +65,22 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 		esac
 	done
 
-	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
-		set -- $(cat /jetty-quickstart)
+	if [ -f /jetty-start ] ; then
+		if [ $JETTY_BASE/start.d -nt /jetty-start ] ; then
+			cat >&2 <<- 'EOWARN'
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the /jetty-start files was generated. Please either delete 
+			         the /jetty-start file or re-run /generate-jetty-start.sh 
+			         from a Dockerfile
+			********************************************************************
+			EOWARN
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from /jetty-start
+		set -- $(cat /jetty-start)
 	else
 		# Do a jetty dry run to set the final command
-		set -- $("$@" --dry-run)
+		set -- $("$@" --dry-run | sed 's/\\$//' )
 	fi
 fi
 

--- a/9.4-jre8/docker-entrypoint.sh
+++ b/9.4-jre8/docker-entrypoint.sh
@@ -38,4 +38,39 @@ if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
 	set -- java $JAVA_OPTIONS "$@"
 fi
 
+if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-to-start* |\
+			--create-files |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			-v )\
+			# It is a terminating command, so exec directly
+		        exec "$@"
+		esac
+	done
+
+	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
+		set -- $(cat /jetty-quickstart)
+	else
+		# Do a jetty dry run to set the final command
+		set -- $("$@" --dry-run)
+	fi
+fi
+
 exec "$@"

--- a/9.4-jre8/docker-entrypoint.sh
+++ b/9.4-jre8/docker-entrypoint.sh
@@ -61,7 +61,7 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 			--version |\
 			-v )\
 			# It is a terminating command, so exec directly
-		        exec "$@"
+			exec "$@"
 		esac
 	done
 

--- a/9.4-jre8/docker-entrypoint.sh
+++ b/9.4-jre8/docker-entrypoint.sh
@@ -81,13 +81,12 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	else
 		# Do a jetty dry run to set the final command
 		"$@" --dry-run > /jetty-start
-		EXIT=$?
 		if [ $(egrep -v '\\$' /jetty-start | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
 			cat /jetty-start \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
-			exit $EXIT
+			exit
 		fi
 		set -- $(sed 's/\\$//' /jetty-start)
 	fi

--- a/9.4-jre8/generate-jetty-start.sh
+++ b/9.4-jre8/generate-jetty-start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -f /jetty-start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -65,11 +65,22 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 		esac
 	done
 
-	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
-		set -- $(cat /jetty-quickstart)
+	if [ -f /jetty-start ] ; then
+		if [ $JETTY_BASE/start.d -nt /jetty-start ] ; then
+			cat >&2 <<- 'EOWARN'
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the /jetty-start files was generated. Please either delete 
+			         the /jetty-start file or re-run /generate-jetty-start.sh 
+			         from a Dockerfile
+			********************************************************************
+			EOWARN
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from /jetty-start
+		set -- $(cat /jetty-start)
 	else
 		# Do a jetty dry run to set the final command
-		set -- $("$@" --dry-run)
+		set -- $("$@" --dry-run | sed 's/\\$//' )
 	fi
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,4 +38,39 @@ if [ "$1" = "java" -a -n "$JAVA_OPTIONS" ] ; then
 	set -- java $JAVA_OPTIONS "$@"
 fi
 
+if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-to-start* |\
+			--create-files |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			-v )\
+			# It is a terminating command, so exec directly
+		        exec "$@"
+		esac
+	done
+
+	if [ -f /jetty-quickstart -a /jetty-quickstart -nt $JETTY_BASE/start.d ] ; then
+		set -- $(cat /jetty-quickstart)
+	else
+		# Do a jetty dry run to set the final command
+		set -- $("$@" --dry-run)
+	fi
+fi
+
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,7 +61,7 @@ if expr "$*" : '^java .*/start\.jar.*$' >/dev/null ; then
 			--version |\
 			-v )\
 			# It is a terminating command, so exec directly
-		        exec "$@"
+			exec "$@"
 		esac
 	done
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -81,13 +81,12 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	else
 		# Do a jetty dry run to set the final command
 		"$@" --dry-run > /jetty-start
-		EXIT=$?
 		if [ $(egrep -v '\\$' /jetty-start | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
 			cat /jetty-start \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
-			exit $EXIT
+			exit
 		fi
 		set -- $(sed 's/\\$//' /jetty-start)
 	fi

--- a/generate-jetty-start.sh
+++ b/generate-jetty-start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -f /jetty-start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start

--- a/update.sh
+++ b/update.sh
@@ -58,7 +58,7 @@ for path in "${paths[@]}"; do
 		[ -d "$path/$variant" ] || continue
 		(
 			set -x
-			cp docker-entrypoint.sh "$path/$variant"
+			cp docker-entrypoint.sh generate-jetty-start.sh "$path/$variant"
 			sed -ri '
 				s/^(FROM) .*/\1 '"$baseImage${variant:+-$variant}"'/;
 				s/^(ENV JETTY_VERSION) .*/\1 '"$fullVersion"'/;


### PR DESCRIPTION
While this is working, I'm not sure this PR is ready to merge yet, I just wanted to create it as the basis of discussion.

This modified docker-entrypoint.sh , so that after the args have been processed, it looks to see if it is a jetty command and if so:
 * If it has a terminating argument (eg --dry-run or --version), then just exec the command
 * Else If a `/jetty-quickstart` files exists and is newer than `$JETTY_BASE/start.d` then set the contents of that file as the command
 * Else set the command as the output of the jetty command with --dry-run appended

This approach:
 * always avoid spawning a nested JVM and the main jetty process is PID 1.   
 * allows a pre-generated jetty-quickstart file to bypass running start.jar at all
 * still supports passing in args and/or commands and acts as you would expect


Some things I'm not really happy with:
 * my sh-foo is not so great, so this could perhaps be done more simply... and I'm a bit worried about any args that have spaces in them.
 * listing the terminating arguments is a little fragile
 * on reflection the file should be called something like `/jetty-command` as it is unrelated to quickstart
 * perhaps we should warn if a `/jetty-command` exists but is older than `start.d`?








