### PR TITLE
Update Jetty versions

### DIFF
--- a/9.2-jre7/Dockerfile
+++ b/9.2-jre7/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.2.21.v20170120
+ENV JETTY_VERSION 9.2.22.v20170606
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.2-jre7/Dockerfile
+++ b/9.2-jre7/Dockerfile
@@ -37,7 +37,7 @@ RUN set -xe \
 	&& for key in $JETTY_GPG_KEYS; do \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
-	&& rm -r "$GNUPGHOME" \
+	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvf jetty.tar.gz --strip-components=1 \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \
 	&& rm -fr demo-base javadoc \

--- a/9.2-jre8/Dockerfile
+++ b/9.2-jre8/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.2.21.v20170120
+ENV JETTY_VERSION 9.2.22.v20170606
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.2-jre8/Dockerfile
+++ b/9.2-jre8/Dockerfile
@@ -37,7 +37,7 @@ RUN set -xe \
 	&& for key in $JETTY_GPG_KEYS; do \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
-	&& rm -r "$GNUPGHOME" \
+	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvf jetty.tar.gz --strip-components=1 \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \
 	&& rm -fr demo-base javadoc \

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.3.19.v20170502
+ENV JETTY_VERSION 9.3.20.v20170531
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -37,7 +37,7 @@ RUN set -xe \
 	&& for key in $JETTY_GPG_KEYS; do \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
-	&& rm -r "$GNUPGHOME" \
+	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvf jetty.tar.gz --strip-components=1 \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \
 	&& rm -fr demo-base javadoc \

--- a/9.3-jre8/alpine/Dockerfile
+++ b/9.3-jre8/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.3.19.v20170502
+ENV JETTY_VERSION 9.3.20.v20170531
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.3-jre8/alpine/Dockerfile
+++ b/9.3-jre8/alpine/Dockerfile
@@ -40,7 +40,7 @@ RUN set -xe \
 	&& for key in $JETTY_GPG_KEYS; do \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
-	&& rm -r "$GNUPGHOME" \
+	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvzf jetty.tar.gz \
 	&& mv jetty-distribution-$JETTY_VERSION/* ./ \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -37,7 +37,7 @@ RUN set -xe \
 	&& for key in $JETTY_GPG_KEYS; do \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
-	&& rm -r "$GNUPGHOME" \
+	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvf jetty.tar.gz --strip-components=1 \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \
 	&& rm jetty.tar.gz* \

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.5.v20170502
+ENV JETTY_VERSION 9.4.6.v20170531
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre8/alpine/Dockerfile
+++ b/9.4-jre8/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.5.v20170502
+ENV JETTY_VERSION 9.4.6.v20170531
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre8/alpine/Dockerfile
+++ b/9.4-jre8/alpine/Dockerfile
@@ -40,7 +40,7 @@ RUN set -xe \
 	&& for key in $JETTY_GPG_KEYS; do \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
-	&& rm -r "$GNUPGHOME" \
+	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvzf jetty.tar.gz \
 	&& mv jetty-home-$JETTY_VERSION/* ./ \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \


### PR DESCRIPTION
Update to Jetty 9.2.22, 9.3.20, and 9.4.6