### PR TITLE
Issue #80 generate-jetty-start.sh Permission denied

### DIFF
--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 	if [ -f $JETTY_START ] ; then
 		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
-			cat >&2 <<- 'EOWARN'
+			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
 			         the $JETTY_START files was generated. Either delete 

--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -30,6 +30,11 @@ if [ -z "$TMPDIR" ] ; then
 	TMPDIR=/tmp/jetty
 	mkdir $TMPDIR 2>/dev/null
 fi
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;
 	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
@@ -71,31 +76,31 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 		EOWARN
 	fi
 
-	if [ -f $JETTY_BASE/jetty.start ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_BASE/jetty.start ] ; then
+	if [ -f $JETTY_START ] ; then
+		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- 'EOWARN'
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
-			         the $JETTY_BASE/jetty.start files was generated. Either delete 
-			         the $JETTY_BASE/jetty.start file or re-run 
-				     /generate-jetty.start.sh 
+			         the $JETTY_START files was generated. Either delete 
+			         the $JETTY_START file or re-run 
+			             /generate-jetty.start.sh 
 			         from a Dockerfile
 			********************************************************************
 			EOWARN
 		fi
-		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from \$JETTY_BASE/jetty.start
-		set -- $(cat $JETTY_BASE/jetty.start)
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+		set -- $(cat $JETTY_START)
 	else
 		# Do a jetty dry run to set the final command
-		"$@" --dry-run > $JETTY_BASE/jetty.start
-		if [ $(egrep -v '\\$' $JETTY_BASE/jetty.start | wc -l ) -gt 1 ] ; then
+		"$@" --dry-run > $JETTY_START
+		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
-			cat $JETTY_BASE/jetty.start \
+			cat $JETTY_START \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
 			exit
 		fi
-		set -- $(sed 's/\\$//' $JETTY_BASE/jetty.start)
+		set -- $(sed 's/\\$//' $JETTY_START)
 	fi
 fi
 

--- a/9.2-jre7/docker-entrypoint.sh
+++ b/9.2-jre7/docker-entrypoint.sh
@@ -26,14 +26,10 @@ if ! command -v -- "$1" >/dev/null 2>&1 ; then
 	set -- java -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
-if [ -z "$TMPDIR" ] ; then
-	TMPDIR=/tmp/jetty
-	mkdir $TMPDIR 2>/dev/null
-fi
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
 
-if [ -z "$JETTY_START" ] ; then
-	JETTY_START=$JETTY_BASE/jetty.start
-fi
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
 
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;

--- a/9.2-jre7/generate-jetty-start.sh
+++ b/9.2-jre7/generate-jetty-start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-rm -f /jetty-start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start
+
+rm -f $JETTY_BASE/jetty.start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start

--- a/9.2-jre7/generate-jetty-start.sh
+++ b/9.2-jre7/generate-jetty-start.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-rm -f $JETTY_BASE/jetty.start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_START

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 	if [ -f $JETTY_START ] ; then
 		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
-			cat >&2 <<- 'EOWARN'
+			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
 			         the $JETTY_START files was generated. Either delete 

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -30,6 +30,11 @@ if [ -z "$TMPDIR" ] ; then
 	TMPDIR=/tmp/jetty
 	mkdir $TMPDIR 2>/dev/null
 fi
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;
 	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
@@ -71,31 +76,31 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 		EOWARN
 	fi
 
-	if [ -f $JETTY_BASE/jetty.start ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_BASE/jetty.start ] ; then
+	if [ -f $JETTY_START ] ; then
+		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- 'EOWARN'
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
-			         the $JETTY_BASE/jetty.start files was generated. Either delete 
-			         the $JETTY_BASE/jetty.start file or re-run 
-				     /generate-jetty.start.sh 
+			         the $JETTY_START files was generated. Either delete 
+			         the $JETTY_START file or re-run 
+			             /generate-jetty.start.sh 
 			         from a Dockerfile
 			********************************************************************
 			EOWARN
 		fi
-		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from \$JETTY_BASE/jetty.start
-		set -- $(cat $JETTY_BASE/jetty.start)
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+		set -- $(cat $JETTY_START)
 	else
 		# Do a jetty dry run to set the final command
-		"$@" --dry-run > $JETTY_BASE/jetty.start
-		if [ $(egrep -v '\\$' $JETTY_BASE/jetty.start | wc -l ) -gt 1 ] ; then
+		"$@" --dry-run > $JETTY_START
+		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
-			cat $JETTY_BASE/jetty.start \
+			cat $JETTY_START \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
 			exit
 		fi
-		set -- $(sed 's/\\$//' $JETTY_BASE/jetty.start)
+		set -- $(sed 's/\\$//' $JETTY_START)
 	fi
 fi
 

--- a/9.2-jre8/docker-entrypoint.sh
+++ b/9.2-jre8/docker-entrypoint.sh
@@ -26,14 +26,10 @@ if ! command -v -- "$1" >/dev/null 2>&1 ; then
 	set -- java -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
-if [ -z "$TMPDIR" ] ; then
-	TMPDIR=/tmp/jetty
-	mkdir $TMPDIR 2>/dev/null
-fi
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
 
-if [ -z "$JETTY_START" ] ; then
-	JETTY_START=$JETTY_BASE/jetty.start
-fi
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
 
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;

--- a/9.2-jre8/generate-jetty-start.sh
+++ b/9.2-jre8/generate-jetty-start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-rm -f /jetty-start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start
+
+rm -f $JETTY_BASE/jetty.start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start

--- a/9.2-jre8/generate-jetty-start.sh
+++ b/9.2-jre8/generate-jetty-start.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-rm -f $JETTY_BASE/jetty.start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_START

--- a/9.3-jre8/alpine/Dockerfile
+++ b/9.3-jre8/alpine/Dockerfile
@@ -72,7 +72,7 @@ RUN set -xe \
 	&& mkdir -p "$TMPDIR" \
 	&& chown -R jetty:jetty "$TMPDIR"
 
-COPY docker-entrypoint.sh /
+COPY docker-entrypoint.sh generate-jetty-start.sh /
 
 USER jetty
 EXPOSE 8080

--- a/9.3-jre8/alpine/docker-entrypoint.sh
+++ b/9.3-jre8/alpine/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 	if [ -f $JETTY_START ] ; then
 		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
-			cat >&2 <<- 'EOWARN'
+			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
 			         the $JETTY_START files was generated. Either delete 

--- a/9.3-jre8/alpine/docker-entrypoint.sh
+++ b/9.3-jre8/alpine/docker-entrypoint.sh
@@ -30,6 +30,11 @@ if [ -z "$TMPDIR" ] ; then
 	TMPDIR=/tmp/jetty
 	mkdir $TMPDIR 2>/dev/null
 fi
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;
 	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
@@ -71,31 +76,31 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 		EOWARN
 	fi
 
-	if [ -f $JETTY_BASE/jetty.start ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_BASE/jetty.start ] ; then
+	if [ -f $JETTY_START ] ; then
+		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- 'EOWARN'
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
-			         the $JETTY_BASE/jetty.start files was generated. Either delete 
-			         the $JETTY_BASE/jetty.start file or re-run 
-				     /generate-jetty.start.sh 
+			         the $JETTY_START files was generated. Either delete 
+			         the $JETTY_START file or re-run 
+			             /generate-jetty.start.sh 
 			         from a Dockerfile
 			********************************************************************
 			EOWARN
 		fi
-		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from \$JETTY_BASE/jetty.start
-		set -- $(cat $JETTY_BASE/jetty.start)
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+		set -- $(cat $JETTY_START)
 	else
 		# Do a jetty dry run to set the final command
-		"$@" --dry-run > $JETTY_BASE/jetty.start
-		if [ $(egrep -v '\\$' $JETTY_BASE/jetty.start | wc -l ) -gt 1 ] ; then
+		"$@" --dry-run > $JETTY_START
+		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
-			cat $JETTY_BASE/jetty.start \
+			cat $JETTY_START \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
 			exit
 		fi
-		set -- $(sed 's/\\$//' $JETTY_BASE/jetty.start)
+		set -- $(sed 's/\\$//' $JETTY_START)
 	fi
 fi
 

--- a/9.3-jre8/alpine/docker-entrypoint.sh
+++ b/9.3-jre8/alpine/docker-entrypoint.sh
@@ -26,14 +26,10 @@ if ! command -v -- "$1" >/dev/null 2>&1 ; then
 	set -- java -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
-if [ -z "$TMPDIR" ] ; then
-	TMPDIR=/tmp/jetty
-	mkdir $TMPDIR 2>/dev/null
-fi
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
 
-if [ -z "$JETTY_START" ] ; then
-	JETTY_START=$JETTY_BASE/jetty.start
-fi
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
 
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;

--- a/9.3-jre8/alpine/generate-jetty-start.sh
+++ b/9.3-jre8/alpine/generate-jetty-start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-rm -f /jetty-start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start
+
+rm -f $JETTY_BASE/jetty.start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start

--- a/9.3-jre8/alpine/generate-jetty-start.sh
+++ b/9.3-jre8/alpine/generate-jetty-start.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-rm -f $JETTY_BASE/jetty.start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_START

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 	if [ -f $JETTY_START ] ; then
 		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
-			cat >&2 <<- 'EOWARN'
+			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
 			         the $JETTY_START files was generated. Either delete 

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -30,6 +30,11 @@ if [ -z "$TMPDIR" ] ; then
 	TMPDIR=/tmp/jetty
 	mkdir $TMPDIR 2>/dev/null
 fi
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;
 	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
@@ -71,31 +76,31 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 		EOWARN
 	fi
 
-	if [ -f $JETTY_BASE/jetty.start ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_BASE/jetty.start ] ; then
+	if [ -f $JETTY_START ] ; then
+		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- 'EOWARN'
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
-			         the $JETTY_BASE/jetty.start files was generated. Either delete 
-			         the $JETTY_BASE/jetty.start file or re-run 
-				     /generate-jetty.start.sh 
+			         the $JETTY_START files was generated. Either delete 
+			         the $JETTY_START file or re-run 
+			             /generate-jetty.start.sh 
 			         from a Dockerfile
 			********************************************************************
 			EOWARN
 		fi
-		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from \$JETTY_BASE/jetty.start
-		set -- $(cat $JETTY_BASE/jetty.start)
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+		set -- $(cat $JETTY_START)
 	else
 		# Do a jetty dry run to set the final command
-		"$@" --dry-run > $JETTY_BASE/jetty.start
-		if [ $(egrep -v '\\$' $JETTY_BASE/jetty.start | wc -l ) -gt 1 ] ; then
+		"$@" --dry-run > $JETTY_START
+		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
-			cat $JETTY_BASE/jetty.start \
+			cat $JETTY_START \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
 			exit
 		fi
-		set -- $(sed 's/\\$//' $JETTY_BASE/jetty.start)
+		set -- $(sed 's/\\$//' $JETTY_START)
 	fi
 fi
 

--- a/9.3-jre8/docker-entrypoint.sh
+++ b/9.3-jre8/docker-entrypoint.sh
@@ -26,14 +26,10 @@ if ! command -v -- "$1" >/dev/null 2>&1 ; then
 	set -- java -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
-if [ -z "$TMPDIR" ] ; then
-	TMPDIR=/tmp/jetty
-	mkdir $TMPDIR 2>/dev/null
-fi
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
 
-if [ -z "$JETTY_START" ] ; then
-	JETTY_START=$JETTY_BASE/jetty.start
-fi
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
 
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;

--- a/9.3-jre8/generate-jetty-start.sh
+++ b/9.3-jre8/generate-jetty-start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-rm -f /jetty-start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start
+
+rm -f $JETTY_BASE/jetty.start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start

--- a/9.3-jre8/generate-jetty-start.sh
+++ b/9.3-jre8/generate-jetty-start.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-rm -f $JETTY_BASE/jetty.start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_START

--- a/9.4-jre8/alpine/Dockerfile
+++ b/9.4-jre8/alpine/Dockerfile
@@ -66,7 +66,7 @@ RUN set -xe \
 	&& mkdir -p "$TMPDIR" \
 	&& chown -R jetty:jetty "$TMPDIR"
 
-COPY docker-entrypoint.sh /
+COPY docker-entrypoint.sh generate-jetty-start.sh /
 
 USER jetty
 EXPOSE 8080

--- a/9.4-jre8/alpine/docker-entrypoint.sh
+++ b/9.4-jre8/alpine/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 	if [ -f $JETTY_START ] ; then
 		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
-			cat >&2 <<- 'EOWARN'
+			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
 			         the $JETTY_START files was generated. Either delete 

--- a/9.4-jre8/alpine/docker-entrypoint.sh
+++ b/9.4-jre8/alpine/docker-entrypoint.sh
@@ -30,6 +30,11 @@ if [ -z "$TMPDIR" ] ; then
 	TMPDIR=/tmp/jetty
 	mkdir $TMPDIR 2>/dev/null
 fi
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;
 	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
@@ -71,31 +76,31 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 		EOWARN
 	fi
 
-	if [ -f $JETTY_BASE/jetty.start ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_BASE/jetty.start ] ; then
+	if [ -f $JETTY_START ] ; then
+		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- 'EOWARN'
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
-			         the $JETTY_BASE/jetty.start files was generated. Either delete 
-			         the $JETTY_BASE/jetty.start file or re-run 
-				     /generate-jetty.start.sh 
+			         the $JETTY_START files was generated. Either delete 
+			         the $JETTY_START file or re-run 
+			             /generate-jetty.start.sh 
 			         from a Dockerfile
 			********************************************************************
 			EOWARN
 		fi
-		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from \$JETTY_BASE/jetty.start
-		set -- $(cat $JETTY_BASE/jetty.start)
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+		set -- $(cat $JETTY_START)
 	else
 		# Do a jetty dry run to set the final command
-		"$@" --dry-run > $JETTY_BASE/jetty.start
-		if [ $(egrep -v '\\$' $JETTY_BASE/jetty.start | wc -l ) -gt 1 ] ; then
+		"$@" --dry-run > $JETTY_START
+		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
-			cat $JETTY_BASE/jetty.start \
+			cat $JETTY_START \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
 			exit
 		fi
-		set -- $(sed 's/\\$//' $JETTY_BASE/jetty.start)
+		set -- $(sed 's/\\$//' $JETTY_START)
 	fi
 fi
 

--- a/9.4-jre8/alpine/docker-entrypoint.sh
+++ b/9.4-jre8/alpine/docker-entrypoint.sh
@@ -26,14 +26,10 @@ if ! command -v -- "$1" >/dev/null 2>&1 ; then
 	set -- java -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
-if [ -z "$TMPDIR" ] ; then
-	TMPDIR=/tmp/jetty
-	mkdir $TMPDIR 2>/dev/null
-fi
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
 
-if [ -z "$JETTY_START" ] ; then
-	JETTY_START=$JETTY_BASE/jetty.start
-fi
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
 
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;

--- a/9.4-jre8/alpine/generate-jetty-start.sh
+++ b/9.4-jre8/alpine/generate-jetty-start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-rm -f /jetty-start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start
+
+rm -f $JETTY_BASE/jetty.start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start

--- a/9.4-jre8/alpine/generate-jetty-start.sh
+++ b/9.4-jre8/alpine/generate-jetty-start.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-rm -f $JETTY_BASE/jetty.start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_START

--- a/9.4-jre8/docker-entrypoint.sh
+++ b/9.4-jre8/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 	if [ -f $JETTY_START ] ; then
 		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
-			cat >&2 <<- 'EOWARN'
+			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
 			         the $JETTY_START files was generated. Either delete 

--- a/9.4-jre8/docker-entrypoint.sh
+++ b/9.4-jre8/docker-entrypoint.sh
@@ -30,6 +30,11 @@ if [ -z "$TMPDIR" ] ; then
 	TMPDIR=/tmp/jetty
 	mkdir $TMPDIR 2>/dev/null
 fi
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;
 	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
@@ -71,31 +76,31 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 		EOWARN
 	fi
 
-	if [ -f $JETTY_BASE/jetty.start ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_BASE/jetty.start ] ; then
+	if [ -f $JETTY_START ] ; then
+		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- 'EOWARN'
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
-			         the $JETTY_BASE/jetty.start files was generated. Either delete 
-			         the $JETTY_BASE/jetty.start file or re-run 
-				     /generate-jetty.start.sh 
+			         the $JETTY_START files was generated. Either delete 
+			         the $JETTY_START file or re-run 
+			             /generate-jetty.start.sh 
 			         from a Dockerfile
 			********************************************************************
 			EOWARN
 		fi
-		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from \$JETTY_BASE/jetty.start
-		set -- $(cat $JETTY_BASE/jetty.start)
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+		set -- $(cat $JETTY_START)
 	else
 		# Do a jetty dry run to set the final command
-		"$@" --dry-run > $JETTY_BASE/jetty.start
-		if [ $(egrep -v '\\$' $JETTY_BASE/jetty.start | wc -l ) -gt 1 ] ; then
+		"$@" --dry-run > $JETTY_START
+		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
-			cat $JETTY_BASE/jetty.start \
+			cat $JETTY_START \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
 			exit
 		fi
-		set -- $(sed 's/\\$//' $JETTY_BASE/jetty.start)
+		set -- $(sed 's/\\$//' $JETTY_START)
 	fi
 fi
 

--- a/9.4-jre8/docker-entrypoint.sh
+++ b/9.4-jre8/docker-entrypoint.sh
@@ -26,14 +26,10 @@ if ! command -v -- "$1" >/dev/null 2>&1 ; then
 	set -- java -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
-if [ -z "$TMPDIR" ] ; then
-	TMPDIR=/tmp/jetty
-	mkdir $TMPDIR 2>/dev/null
-fi
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
 
-if [ -z "$JETTY_START" ] ; then
-	JETTY_START=$JETTY_BASE/jetty.start
-fi
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
 
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;

--- a/9.4-jre8/generate-jetty-start.sh
+++ b/9.4-jre8/generate-jetty-start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-rm -f /jetty-start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start
+
+rm -f $JETTY_BASE/jetty.start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start

--- a/9.4-jre8/generate-jetty-start.sh
+++ b/9.4-jre8/generate-jetty-start.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-rm -f $JETTY_BASE/jetty.start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_START

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 	if [ -f $JETTY_START ] ; then
 		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
-			cat >&2 <<- 'EOWARN'
+			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
 			         the $JETTY_START files was generated. Either delete 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,6 +30,11 @@ if [ -z "$TMPDIR" ] ; then
 	TMPDIR=/tmp/jetty
 	mkdir $TMPDIR 2>/dev/null
 fi
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;
 	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
@@ -71,31 +76,31 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 		EOWARN
 	fi
 
-	if [ -f $JETTY_BASE/jetty.start ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_BASE/jetty.start ] ; then
+	if [ -f $JETTY_START ] ; then
+		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- 'EOWARN'
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since
-			         the $JETTY_BASE/jetty.start files was generated. Either delete 
-			         the $JETTY_BASE/jetty.start file or re-run 
-				     /generate-jetty.start.sh 
+			         the $JETTY_START files was generated. Either delete 
+			         the $JETTY_START file or re-run 
+			             /generate-jetty.start.sh 
 			         from a Dockerfile
 			********************************************************************
 			EOWARN
 		fi
-		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start command from \$JETTY_BASE/jetty.start
-		set -- $(cat $JETTY_BASE/jetty.start)
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+		set -- $(cat $JETTY_START)
 	else
 		# Do a jetty dry run to set the final command
-		"$@" --dry-run > $JETTY_BASE/jetty.start
-		if [ $(egrep -v '\\$' $JETTY_BASE/jetty.start | wc -l ) -gt 1 ] ; then
+		"$@" --dry-run > $JETTY_START
+		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
-			cat $JETTY_BASE/jetty.start \
+			cat $JETTY_START \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
 			exit
 		fi
-		set -- $(sed 's/\\$//' $JETTY_BASE/jetty.start)
+		set -- $(sed 's/\\$//' $JETTY_START)
 	fi
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,14 +26,10 @@ if ! command -v -- "$1" >/dev/null 2>&1 ; then
 	set -- java -jar "$JETTY_HOME/start.jar" "$@"
 fi
 
-if [ -z "$TMPDIR" ] ; then
-	TMPDIR=/tmp/jetty
-	mkdir $TMPDIR 2>/dev/null
-fi
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
 
-if [ -z "$JETTY_START" ] ; then
-	JETTY_START=$JETTY_BASE/jetty.start
-fi
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
 
 case "$JAVA_OPTIONS" in
 	*-Djava.io.tmpdir=*) ;;

--- a/generate-jetty-start.sh
+++ b/generate-jetty-start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-rm -f /jetty-start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > /jetty-start
+
+rm -f $JETTY_BASE/jetty.start
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start

--- a/generate-jetty-start.sh
+++ b/generate-jetty-start.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-rm -f $JETTY_BASE/jetty.start
-/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_BASE/jetty.start
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+/docker-entrypoint.sh --dry-run | sed 's/\\$//' > $JETTY_START


### PR DESCRIPTION
Fixes for #80 

Moved the /jetty-start file to $JETTY_BASE/jetty.start, where it can be
written to by the jetty user.

Added a warning in the docker-entrypoint.sh if the user is not 'jetty'