### PR TITLE
http2 breaks w/o 9.4.8.v20171121

### DIFF
--- a/9.2-jre7/Dockerfile
+++ b/9.2-jre7/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.2.22.v20170606
+ENV JETTY_VERSION 9.2.24.v20180105
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.2-jre8/Dockerfile
+++ b/9.2-jre8/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.2.22.v20170606
+ENV JETTY_VERSION 9.2.24.v20180105
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.3.21.v20170918
+ENV JETTY_VERSION 9.3.22.v20171030
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.3-jre8/alpine/Dockerfile
+++ b/9.3-jre8/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.3.21.v20170918
+ENV JETTY_VERSION 9.3.22.v20171030
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.7.v20170914
+ENV JETTY_VERSION 9.4.8.v20171121
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre8/alpine/Dockerfile
+++ b/9.4-jre8/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.7.v20170914
+ENV JETTY_VERSION 9.4.8.v20171121
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)


### PR DESCRIPTION
Currently `--add-to-start=http2` breaks with the following error:
```
java.lang.IllegalStateException: Cannot read file: modules/alpn-impl/alpn-1.8.0_151.mod
        at org.eclipse.jetty.start.Modules.registerModule(Modules.java:200)
        at org.eclipse.jetty.start.Modules.enable(Modules.java:353)
        at org.eclipse.jetty.start.Modules.enable(Modules.java:358)
        at org.eclipse.jetty.start.Modules.enable(Modules.java:375)
        at org.eclipse.jetty.start.Modules.enable(Modules.java:284)
        at org.eclipse.jetty.start.BaseBuilder.build(BaseBuilder.java:127)
        at org.eclipse.jetty.start.Main.start(Main.java:455)
        at org.eclipse.jetty.start.Main.main(Main.java:78)
```
Based upon #22 this looked like should be new version of jetty required; after bumping the jetty version to `9.4.8.v20171121` everything works fine.