### PR TITLE
Add "Architectures" to "generate-stackbrew-library.sh" output

### DIFF
--- a/9.2-jre7/arches
+++ b/9.2-jre7/arches
@@ -1,0 +1,1 @@
+amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/9.2-jre8/arches
+++ b/9.2-jre8/arches
@@ -1,0 +1,1 @@
+amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/9.3-jre8/alpine/arches
+++ b/9.3-jre8/alpine/arches
@@ -1,0 +1,1 @@
+amd64, arm32v6, arm64v8, i386, ppc64le, s390x

--- a/9.3-jre8/arches
+++ b/9.3-jre8/arches
@@ -1,0 +1,1 @@
+amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/9.4-jre8/alpine/arches
+++ b/9.4-jre8/alpine/arches
@@ -1,0 +1,1 @@
+amd64, arm32v6, arm64v8, i386, ppc64le, s390x

--- a/9.4-jre8/arches
+++ b/9.4-jre8/arches
@@ -1,0 +1,1 @@
+amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -96,6 +96,7 @@ for path in "${paths[@]}"; do
 	cat <<-EOE
 
 		Tags:$(IFS=, ; echo "${tags[*]/#/ }")
+		Architectures: $(< "$directory/arches")
 		Directory: $directory
 		GitCommit: $commit
 	EOE


### PR DESCRIPTION
Closes #68

For repos under https://github.com/docker-library, we generally invoke `bashbrew` from within `generate-stackbrew-library.sh` to get the `Architectures` list of the image we're `FROM` directly, but I wasn't sure if you wanted to add that additional dependency for running the script here, so I wrote a quick one-liner to do the work as a one-off into files that get checked in (which also makes it easier to munge them if it turns out one of them fails to build or doesn't run properly etc and needs to be excluded).

As always, happy to adjust, rebase, amend, etc.  I could also set up Travis to test `i386`, if that's deemed useful (`memcached` has an example of that: https://github.com/docker-library/memcached/blob/5a09fc033d8e239ebecf1edb20b7f921d51de591/.travis.yml).