### PR TITLE
let users provide external volume for webapps in the Kitematic UI

### DIFF
--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added 
 RUN groupadd -r jetty && useradd -r -g jetty jetty
 
 ENV JETTY_HOME /usr/local/jetty

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -58,6 +58,7 @@ RUN set -xe \
 	&& chown -R jetty:jetty "$TMPDIR"
 
 COPY docker-entrypoint.sh generate-jetty-start.sh /
+VOLUME /var/lib/jetty/webapps
 
 USER jetty
 EXPOSE 8080


### PR DESCRIPTION
using the image with Kitematic - the UI that is shipped with docker - I cannot provide volumes.

The Kitematic uses the dockerfile to offer the user a UI for his volumes.
As long as the dockerfile does not declare it's volumes - the UI cannot do that... 

