### PR TITLE
Add "gpgconf --kill all" (and pgp-happy-eyeballs in CI) to help cut down on general GPG keyserver flakiness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
 
 before_script:
   - env | sort
+  - wget -qO- 'https://github.com/tianon/pgp-happy-eyeballs/raw/master/hack-my-builds.sh' | bash
   - cd "${VERSION}${VARIANT:+/$VARIANT}"
   - image="jetty:${VERSION}${VARIANT:+-$VARIANT}"
 

--- a/9.2-jre7/Dockerfile
+++ b/9.2-jre7/Dockerfile
@@ -35,7 +35,7 @@ RUN set -xe \
 	&& curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& for key in $JETTY_GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
+		gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
 	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvf jetty.tar.gz --strip-components=1 \

--- a/9.2-jre8/Dockerfile
+++ b/9.2-jre8/Dockerfile
@@ -35,7 +35,7 @@ RUN set -xe \
 	&& curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& for key in $JETTY_GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
+		gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
 	&& gpgconf --kill all \
 	&& rm -rf "$GNUPGHOME" \

--- a/9.2-jre8/Dockerfile
+++ b/9.2-jre8/Dockerfile
@@ -37,6 +37,7 @@ RUN set -xe \
 	&& for key in $JETTY_GPG_KEYS; do \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
+	&& gpgconf --kill all \
 	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvf jetty.tar.gz --strip-components=1 \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -35,7 +35,7 @@ RUN set -xe \
 	&& curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& for key in $JETTY_GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
+		gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
 	&& gpgconf --kill all \
 	&& rm -rf "$GNUPGHOME" \

--- a/9.3-jre8/Dockerfile
+++ b/9.3-jre8/Dockerfile
@@ -37,6 +37,7 @@ RUN set -xe \
 	&& for key in $JETTY_GPG_KEYS; do \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
+	&& gpgconf --kill all \
 	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvf jetty.tar.gz --strip-components=1 \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \

--- a/9.3-jre8/alpine/Dockerfile
+++ b/9.3-jre8/alpine/Dockerfile
@@ -33,13 +33,14 @@ ENV JETTY_GPG_KEYS \
 RUN set -xe \
 	# Install required packages for build time. Will be removed when build finishes.
 	&& apk add --no-cache --virtual .build-deps gnupg curl \
-
+	\
 	&& curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz \
 	&& curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& for key in $JETTY_GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
+		gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
+	&& gpgconf --kill all \
 	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvzf jetty.tar.gz \
 	&& mv jetty-distribution-$JETTY_VERSION/* ./ \
@@ -47,7 +48,7 @@ RUN set -xe \
 	&& rm -fr demo-base javadoc \
 	&& rm jetty.tar.gz* \
 	&& rm -fr jetty-distribution-$JETTY_VERSION/ \
-
+	\
 	# Remove installed packages and various cleanup
 	&& apk del .build-deps \
 	&& rm -fr .build-deps \

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -35,7 +35,7 @@ RUN set -xe \
 	&& curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& for key in $JETTY_GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
+		gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
 	&& gpgconf --kill all \
 	&& rm -rf "$GNUPGHOME" \

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -37,6 +37,7 @@ RUN set -xe \
 	&& for key in $JETTY_GPG_KEYS; do \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
+	&& gpgconf --kill all \
 	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvf jetty.tar.gz --strip-components=1 \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \

--- a/9.4-jre8/alpine/Dockerfile
+++ b/9.4-jre8/alpine/Dockerfile
@@ -33,20 +33,21 @@ ENV JETTY_GPG_KEYS \
 RUN set -xe \
 	# Install required packages for build time. Will be removed when build finishes.
 	&& apk add --no-cache --virtual .build-deps gnupg curl \
-
+	\
 	&& curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz \
 	&& curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& for key in $JETTY_GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
+		gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; done \
 	&& gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz \
+	&& gpgconf --kill all \
 	&& rm -rf "$GNUPGHOME" \
 	&& tar -xvzf jetty.tar.gz \
 	&& mv jetty-home-$JETTY_VERSION/* ./ \
 	&& sed -i '/jetty-logging/d' etc/jetty.conf \
 	&& rm jetty.tar.gz* \
 	&& rm -fr jetty-home-$JETTY_VERSION/ \
-
+	\
 	# Remove installed packages and various cleanup
 	&& apk del .build-deps \
 	&& rm -fr .build-deps \


### PR DESCRIPTION
As discussed in https://github.com/appropriate/docker-jetty/pull/99#issuecomment-460510162.

This also adds `--batch` (see https://bugs.debian.org/913614 and PRs linked from docker-library/busybox#55).