### PR TITLE
Upgrade Jetty 9.4 images to jetty-9.4.21.v20190926

### DIFF
--- a/9.4-jre11/Dockerfile
+++ b/9.4-jre11/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.18.v20190429
+ENV JETTY_VERSION 9.4.20.v20190813
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre11/Dockerfile
+++ b/9.4-jre11/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.20.v20190813
+ENV JETTY_VERSION 9.4.21.v20190926
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.18.v20190429
+ENV JETTY_VERSION 9.4.20.v20190813
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.20.v20190813
+ENV JETTY_VERSION 9.4.21.v20190926
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre8/alpine/Dockerfile
+++ b/9.4-jre8/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.18.v20190429
+ENV JETTY_VERSION 9.4.20.v20190813
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre8/alpine/Dockerfile
+++ b/9.4-jre8/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.20.v20190813
+ENV JETTY_VERSION 9.4.21.v20190926
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)


### PR DESCRIPTION
Upgrades all Jetty 9.4 images to [9.4.21.v20190926](https://www.eclipse.org/jetty/download.html) ([changelog](https://raw.githubusercontent.com/eclipse/jetty.project/jetty-9.4.21.v20190926/VERSION.txt)):

- **[9.4-jre11/Dockerfile](https://github.com/appropriate/docker-jetty/pull/115/files#diff-8e2a46e2615784aee0e1542d5b719a2bR11)**
- **[9.4-jre8/alpine/Dockerfile](https://github.com/appropriate/docker-jetty/pull/115/files#diff-169d673d4f5fe9cfd4c29264a0e27526R11)**
- **[9.4-jre8/Dockerfile](https://github.com/appropriate/docker-jetty/pull/115/files#diff-dad6c4a2a53860754faaf15e201d8b0dR11)**

Images for Jetty 9.3 and 9.2 remain unmodified, as their versions are [still current](https://www.eclipse.org/jetty/previousversions.html):

- **9.2-jre7/Dockerfile** has version **[9.2.28.v20190418](https://github.com/appropriate/docker-jetty/blob/master/9.2-jre7/Dockerfile#L11)**
- **9.2-jre8/Dockerfile** has version **[9.2.28.v20190418](https://github.com/appropriate/docker-jetty/blob/master/9.2-jre8/Dockerfile#L11)**
- **9.3-jre8/alpine/Dockerfile** has version **[9.3.27.v20190418](https://github.com/appropriate/docker-jetty/blob/master/9.3-jre8/alpine/Dockerfile#L11)**
- **9.3-jre8/Dockerfile** has version **[9.3.27.v20190418](https://github.com/appropriate/docker-jetty/blob/master/9.3-jre8/Dockerfile#L11)**

