### PR TITLE
Upgrade jetty 9.4.24

### DIFF
--- a/9.4-jre11/Dockerfile
+++ b/9.4-jre11/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.23.v20191118
+ENV JETTY_VERSION 9.4.24.v20191120
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)

--- a/9.4-jre8/Dockerfile
+++ b/9.4-jre8/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JETTY_HOME/bin:$PATH
 RUN mkdir -p "$JETTY_HOME"
 WORKDIR $JETTY_HOME
 
-ENV JETTY_VERSION 9.4.23.v20191118
+ENV JETTY_VERSION 9.4.24.v20191120
 ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 
 # GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)


### PR DESCRIPTION
```
jetty-9.4.24.v20191120 - 20 November 2019
 + 3083 The ini-template for jetty.console-capture.dir does not match the
   default value
 + 4128 OpenIdCredetials can't decode JWT ID token
 + 4334 Better test ErrorHandler changes
```