### PR TITLE
Remove arm arch for jdk13

### DIFF
--- a/9.4-jdk13-slim/arches
+++ b/9.4-jdk13-slim/arches
@@ -1,1 +1,1 @@
-amd64, arm64v8
+amd64

--- a/9.4-jdk13/arches
+++ b/9.4-jdk13/arches
@@ -1,1 +1,1 @@
-amd64, arm64v8
+amd64


### PR DESCRIPTION
Remove arm architecture for jdk13 images (fix for #121)
Signed-off-by: Greg Wilkins <gregw@webtide.com>