### PR TITLE
remove arm from jre11

### DIFF
--- a/9.4-jre11-slim/arches
+++ b/9.4-jre11-slim/arches
@@ -1,1 +1,1 @@
-amd64, arm64v8
+amd64

--- a/9.4-jre11/arches
+++ b/9.4-jre11/arches
@@ -1,1 +1,1 @@
-amd64, arm64v8
+amd64


### PR DESCRIPTION
arm architecture also no longer supported on jre11!

Signed-off-by: Greg Wilkins <gregw@webtide.com>