### PR TITLE
Drop broken waffle.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# About this Repo [![Build Status](https://travis-ci.org/appropriate/docker-jetty.svg?branch=master)](https://travis-ci.org/appropriate/docker-jetty)[![Stories in Ready](https://badge.waffle.io/appropriate/docker-jetty.png?label=ready&title=Ready)](https://waffle.io/appropriate/docker-jetty)
+# About this Repo
+
+[![Build Status](https://travis-ci.org/appropriate/docker-jetty.svg?branch=master)](https://travis-ci.org/appropriate/docker-jetty)
 
 This is the Git repo of the official Docker image for [jetty](https://registry.hub.docker.com/_/jetty/). See the
 Hub page for the full readme on how to use the Docker image and for information regarding contributing and issues.


### PR DESCRIPTION
Looks like waffle.io has gone out of business:
https://www.bluehousegroup.com/assets/Uploads/_resampled/ResizedImageWzYwMCwyNTJd/Waffle.io-Shutting-Down.png

Ping @gregw 